### PR TITLE
Add possibility to deploy external computes for standalone-roles purpose

### DIFF
--- a/deploy-scripts/06-external-compute.sh
+++ b/deploy-scripts/06-external-compute.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+exec > >(tee -a 06-external-compute.log)
+exec 2>&1
+
+set -eux
+date
+
+STACK_NAME=${STACK_NAME:-"overcloud"}
+
+source stackrc
+
+
+# Set up tripleo-ansible repo and download standalone-roles patches as explained in https://etherpad.opendev.org/p/tripleo-standalone-roles#L72
+
+# Customize tripleo-ansible inventory.
+
+# 1. Add host vars files under tripleo_ansible/inventory/host_vars/ for each external computes.
+# https://etherpad.opendev.org/p/tripleo-standalone-roles#L89
+# Example of tripleo_ansible/inventory/host_vars/compute-0
+# ansible_host: 10.98.0.<%ip%>
+# ctlplane_ip: 192.168.24.<%ip%>
+# internal_api_ip: 172.16.2.<%ip%>
+# tenant_ip: 172.16.0.<%ip%>
+# fqdn_internal_api: <stack-name>-external-compute-<count>.localdomain
+
+# <%ip%> depends on external computes count number. For external compute it starts from 160
+
+# 2. Add ansible hosts to the compute host group in tripleo_ansible/inventory/02-computes
+
+pushd /home/stack/tripleo-ansible
+
+scripts/tripleo-standalone-vars --output-file 99-standalone-vars \
+  -c /home/stack/overcloud-deploy/${STACK_NAME}/config-download/${STACK_NAME}
+
+cp 99-standalone-vars tripleo_ansible/inventory/99-standalone-vars
+
+time ansible-playbook -i tripleo_ansible/inventory \
+  --become \
+   tripleo_ansible/playbooks/deploy-overcloud-compute.yml \
+  $@
+
+date

--- a/tripleo.yaml
+++ b/tripleo.yaml
@@ -16,6 +16,9 @@ parameters:
   ComputeCount:
     type: number
     default: 1
+  ExternalComputeCount:
+    type: number
+    default: 0
   ControllerFlavor:
     type: string
     default: ci.m4.xlarge
@@ -430,6 +433,32 @@ resources:
           ManagementNetwork: {get_resource: ManagementNetwork}
           DeployNetwork: {get_resource: DeployNetwork}
           RoleLower: novacompute
+
+  ExternalComputes:
+    type: OS::Heat::ResourceGroup
+    depends_on:
+      - DeploySubnet
+      - ManagementSubnet
+    properties:
+      count: {get_param: ExternalComputeCount}
+      resource_def:
+        type: overcloud-server.yaml
+        properties:
+          flavor: {get_param: ComputeFlavor}
+          key_name: {get_resource: KeyPair}
+          name:
+            list_join:
+              - '-'
+              - - {get_param: OS::stack_name}
+                - 'external-compute'
+                - '%index%'
+          image: {get_param: OvercloudImage}
+          index: |
+            %index%
+          SubnetStart: 160
+          ManagementNetwork: {get_resource: ManagementNetwork}
+          DeployNetwork: {get_resource: DeployNetwork}
+          RoleLower: external-novacompute
 
 outputs:
   UndercloudFloatingIP:

--- a/undercloud-config.yaml
+++ b/undercloud-config.yaml
@@ -88,6 +88,9 @@ resources:
           - path: /home/stack/05-overcloud-deploy.sh
             permissions: '0755'
             content: {get_file: deploy-scripts/05-overcloud-deploy.sh}
+          - path: /home/stack/06-external-compute.sh
+            permissions: '0755'
+            content: {get_file: deploy-scripts/06-external-compute.sh}
           - path: /home/stack/deploy.sh
             permissions: '0755'
             content: {get_file: deploy-scripts/deploy.sh}


### PR DESCRIPTION
Add new ExternalComputes ResourceGroup and additional deploy script to be able to develop and test standalone-roles changes[1]. The external compute is created only if requested, by default no external compute is created.

[1]https://review.opendev.org/q/topic:standalone-roles

Signed-off-by: Mikolaj Ciecierski <mciecier@redhat.com>